### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,13 @@
 language: node_js
 node_js:
   - "6"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
 before_script:
   - cp config/localSettings.js.in config/localSettings.js


### PR DESCRIPTION
Apparently we need to build native modules for something in node.js,
to do that, we need a C++11 standard-compliant compiler.